### PR TITLE
Fix pad alignment

### DIFF
--- a/ESP8266.pretty/ESP-07v2.kicad_mod
+++ b/ESP8266.pretty/ESP-07v2.kicad_mod
@@ -37,7 +37,7 @@
   (pad 7 thru_hole oval (at 0 12) (size 2.5 1.1) (drill 0.65 (offset -0.7 0)) (layers *.Cu *.Mask F.Paste F.SilkS))
   (pad 8 thru_hole oval (at 0 14) (size 2.5 1.1) (drill 0.65 (offset -0.7 0)) (layers *.Cu *.Mask F.Paste F.SilkS))
   (pad 9 thru_hole oval (at 14 14) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.Paste F.SilkS))
-  (pad 10 thru_hole oval (at 14 12) (size 2.5 1.1) (drill 0.65 (offset 0.6 0)) (layers *.Cu *.Mask F.Paste F.SilkS))
+  (pad 10 thru_hole oval (at 14 12) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.Paste F.SilkS))
   (pad 11 thru_hole oval (at 14 10) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.Paste F.SilkS))
   (pad 12 thru_hole oval (at 14 8) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.Paste F.SilkS))
   (pad 13 thru_hole oval (at 14 6) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.Paste F.SilkS))

--- a/ESP8266.pretty/ESP-12.kicad_mod
+++ b/ESP8266.pretty/ESP-12.kicad_mod
@@ -38,7 +38,7 @@
   (pad 7 thru_hole oval (at 0 12) (size 2.5 1.1) (drill 0.65 (offset -0.7 0)) (layers *.Cu *.Mask F.SilkS))
   (pad 8 thru_hole oval (at 0 14) (size 2.5 1.1) (drill 0.65 (offset -0.7 0)) (layers *.Cu *.Mask F.SilkS))
   (pad 9 thru_hole oval (at 14 14) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.SilkS))
-  (pad 10 thru_hole oval (at 14 12) (size 2.5 1.1) (drill 0.65 (offset 0.6 0)) (layers *.Cu *.Mask F.SilkS))
+  (pad 10 thru_hole oval (at 14 12) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.SilkS))
   (pad 11 thru_hole oval (at 14 10) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.SilkS))
   (pad 12 thru_hole oval (at 14 8) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.SilkS))
   (pad 13 thru_hole oval (at 14 6) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.SilkS))

--- a/ESP8266.pretty/ESP-12E.kicad_mod
+++ b/ESP8266.pretty/ESP-12E.kicad_mod
@@ -38,7 +38,7 @@
   (pad 7 thru_hole oval (at 0 12) (size 2.5 1.1) (drill 0.65 (offset -0.7 0)) (layers *.Cu *.Mask F.SilkS))
   (pad 8 thru_hole oval (at 0 14) (size 2.5 1.1) (drill 0.65 (offset -0.7 0)) (layers *.Cu *.Mask F.SilkS))
   (pad 9 thru_hole oval (at 14 14) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.SilkS))
-  (pad 10 thru_hole oval (at 14 12) (size 2.5 1.1) (drill 0.65 (offset 0.6 0)) (layers *.Cu *.Mask F.SilkS))
+  (pad 10 thru_hole oval (at 14 12) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.SilkS))
   (pad 11 thru_hole oval (at 14 10) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.SilkS))
   (pad 12 thru_hole oval (at 14 8) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.SilkS))
   (pad 13 thru_hole oval (at 14 6) (size 2.5 1.1) (drill 0.65 (offset 0.7 0)) (layers *.Cu *.Mask F.SilkS))


### PR DESCRIPTION
Some modules had a pad aligment of 0.6, where all other pads on the
module were aligned to 0.7. This was identified here:
https://github.com/tmaczukin/kicad-ESP8266/commit/02fad0300118fdf57f9066b67a19b04c2f466f02